### PR TITLE
Small code improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,17 +90,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "blake2"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
-dependencies = [
- "crypto-mac",
- "digest",
- "opaque-debug",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,16 +263,6 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if",
  "lazy_static",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -889,7 +868,6 @@ name = "rfs"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "blake2",
  "bytes",
  "capnp",
  "capnpc",
@@ -1133,12 +1111,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "subtle"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ capnpc = "0.14.4"
 [dependencies]
 capnp = "0.14.3"
 anyhow = "1.0.44"
-blake2 = "0.9.2"
 time = "0.3.3"
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "sqlite" ] }
 tokio = { version = "1.11.0", features = ["full"] }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -11,14 +11,6 @@ trait Hex {
     fn hex(&self) -> String;
 }
 
-impl Hex for Vec<u8> {
-    fn hex(&self) -> String {
-        self.iter()
-            .map(|x| -> String { format!("{:02x}", x) })
-            .collect()
-    }
-}
-
 impl Hex for &[u8] {
     fn hex(&self) -> String {
         self.iter()
@@ -106,12 +98,12 @@ impl Cache {
         let meta = file.metadata().await?;
         if meta.len() > 0 {
             // chunk is already downloaded
-            debug!("block cache hit: {}", block.hash.hex());
+            debug!("block cache hit: {}", block.hash.as_slice().hex());
             locker.unlock().await?;
             return Ok((meta.len(), file));
         }
 
-        debug!("downloading block: {}", block.hash.hex());
+        debug!("downloading block: {}", block.hash.as_slice().hex());
         let size = self.download(&mut file, block).await?;
 
         locker.unlock().await?;

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -24,7 +24,7 @@ use tokio::{
 const CHUNK_SIZE: usize = 512 * 1024; // 512k and is hardcoded in the hub. the block_size value is not used
 const TTL: Duration = Duration::from_secs(60 * 60 * 24 * 365);
 const LRU_CAP: usize = 5; // Least Recently Used File Capacity
-type FHash = Vec<u8>;
+type FHash = [u8; 16];
 type BlockSize = u64;
 
 #[derive(Clone)]
@@ -132,7 +132,7 @@ impl Filesystem {
 
         'blocks: for block in file_metadata.blocks.iter().skip(chunk_index) {
             // hash works as a key inside the LRU
-            let hash = block.hash.clone();
+            let hash = block.hash;
 
             // getting the file descriptor from the LRU or from the cache if not found in the LRU
             let lru = self.lru.lock().await.pop(&hash);

--- a/src/meta/types.rs
+++ b/src/meta/types.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use capnp::{message, serialize};
 use nix::unistd::{Group, User};
 use polyfuse::reply::FileAttr;
+use std::convert::TryInto;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -24,8 +25,8 @@ pub struct SubDir {
 
 #[derive(Debug, Clone)]
 pub struct FileBlock {
-    pub hash: Vec<u8>,
-    pub key: Vec<u8>,
+    pub hash: [u8; 16],
+    pub key: [u8; 16],
 }
 
 #[derive(Debug, Clone)]
@@ -116,8 +117,14 @@ impl Dir {
                                 let mut result = vec![];
                                 for block in blocks {
                                     result.push(FileBlock {
-                                        hash: Vec::from(block.get_hash()?),
-                                        key: Vec::from(block.get_key()?),
+                                        hash: block
+                                            .get_hash()?
+                                            .try_into()
+                                            .expect("block hash is 16 bytes"),
+                                        key: block
+                                            .get_key()?
+                                            .try_into()
+                                            .expect("block encryption key is 16 bytes"),
                                     });
                                 }
                                 result


### PR DESCRIPTION
- Add pre-calculated root hash (hash of empty string)
- Remove hash infrastructure only used to calculate the prior
- Remove now unused blake2 depencendy
- Inline block key and hash, as they are known to be 16 bytes long

Signed-off-by: Lee Smet <lee.smet@hotmail.com>