### PR TITLE
rfs library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-recursion",
+ "async-trait",
  "bb8-redis",
  "bytes",
  "capnp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,12 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
-name = "arc-swap"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
-
-[[package]]
 name = "assert_cmd"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +46,17 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -96,6 +101,30 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bb8"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1627eccf3aa91405435ba240be23513eeca466b5dc33866422672264de061582"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-util",
+ "parking_lot 0.12.0",
+ "tokio",
+]
+
+[[package]]
+name = "bb8-redis"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b081e2864000416c5a4543fed63fb8dd979c4a0806b071fddab0e548c6cd4c74"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "redis",
+]
 
 [[package]]
 name = "bitflags"
@@ -1173,17 +1202,14 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80b5f38d7f5a020856a0e16e40a9cfabf88ae8f0e4c2dcd8a3114c1e470852"
 dependencies = [
- "arc-swap",
  "async-trait",
  "bytes",
  "combine",
  "dtoa",
- "futures",
  "futures-util",
  "itoa 0.4.8",
  "percent-encoding",
  "pin-project-lite",
- "sha1",
  "tokio",
  "tokio-util 0.6.9",
  "url",
@@ -1255,6 +1281,8 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "async-recursion",
+ "bb8-redis",
  "bytes",
  "capnp",
  "capnpc",
@@ -1268,7 +1296,6 @@ dependencies = [
  "lru",
  "nix",
  "polyfuse",
- "redis",
  "reqwest",
  "simple_logger",
  "snap",
@@ -1392,21 +1419,6 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,14 @@ edition = "2018"
 [build-dependencies]
 capnpc = "0.14.4"
 
+[[bin]]
+name = "rfs"
+path = "src/main.rs"
+
+[lib]
+name = "rfs"
+path = "src/lib.rs"
+
 [dependencies]
 capnp = "0.14.3"
 anyhow = "1.0.44"
@@ -16,7 +24,6 @@ tokio = { version = "1.11.0", features = ["full"] }
 libc = "0.2"
 futures = "0.3"
 thiserror = "1.0"
-redis = { version = "0.21.0", features = ["tokio-comp", "aio", "connection-manager"] }
 xxtea = "0.2.0"
 bytes = "1.1.0"
 log = "0.4"
@@ -30,6 +37,8 @@ daemonize = "0.4.1"
 snap = "1.0.5"
 git-version = "0.3.5"
 tempfile = "3.3.0"
+async-recursion = "1.0.0"
+bb8-redis = "0.11.0"
 
 [dependencies.polyfuse]
 branch = "master"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ git-version = "0.3.5"
 tempfile = "3.3.0"
 async-recursion = "1.0.0"
 bb8-redis = "0.11.0"
+async-trait = "0.1.53"
 
 [dependencies.polyfuse]
 branch = "master"

--- a/lib.rs
+++ b/lib.rs
@@ -1,3 +1,0 @@
-pub mod cache;
-pub mod fs;
-pub mod meta;

--- a/lib.rs
+++ b/lib.rs
@@ -1,0 +1,3 @@
+pub mod cache;
+pub mod fs;
+pub mod meta;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -112,8 +112,10 @@ impl Cache {
 
     /// direct downloads all the file blocks from remote and write it to output
     pub async fn direct(&mut self, blocks: &[FileBlock], out: &mut File) -> Result<()> {
+        use tokio::io::copy;
         for (index, block) in blocks.iter().enumerate() {
-            self.download(out, block)
+            let (_, mut chunk) = self.get(&block).await?;
+            copy(&mut chunk, out)
                 .await
                 .with_context(|| format!("failed to download block {}", index))?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,13 @@
+#[macro_use]
+extern crate anyhow;
+#[macro_use]
+extern crate thiserror;
+#[macro_use]
+extern crate log;
+
+pub mod schema_capnp {
+    include!(concat!(env!("OUT_DIR"), "/schema_capnp.rs"));
+}
+
+pub mod cache;
+pub mod meta;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@ extern crate anyhow;
 extern crate thiserror;
 #[macro_use]
 extern crate log;
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
 
 pub mod schema_capnp {
     include!(concat!(env!("OUT_DIR"), "/schema_capnp.rs"));
@@ -11,3 +14,72 @@ pub mod schema_capnp {
 
 pub mod cache;
 pub mod meta;
+
+use cache::Cache;
+use meta::{EntryKind, Metadata};
+
+struct CopyVisitor<'a> {
+    meta: &'a Metadata,
+    cache: &'a mut Cache,
+    root: &'a Path,
+}
+
+#[async_trait::async_trait]
+impl<'a> meta::WalkVisitor for CopyVisitor<'a> {
+    async fn visit<P: AsRef<Path> + Send + Sync>(
+        &mut self,
+        path: P,
+        entry: &meta::Entry,
+    ) -> Result<()> {
+        use tokio::fs::OpenOptions;
+
+        let rooted = self.root.join(path.as_ref().strip_prefix("/")?);
+        let acl = self
+            .meta
+            .aci(&entry.node.acl)
+            .await
+            .map(|a| a.mode & 0o777)
+            .unwrap_or(0o666);
+
+        println!("creating file: {:?} {:?}", path.as_ref(), rooted);
+        match &entry.kind {
+            EntryKind::Dir(_) => {
+                fs::create_dir_all(&rooted)
+                    .with_context(|| format!("failed to create directory '{:?}'", rooted))?;
+            }
+            EntryKind::File(file) => {
+                let mut fd = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .mode(acl)
+                    .open(&rooted)
+                    .await
+                    .with_context(|| format!("failed to create directory '{:?}'", rooted))?;
+
+                self.cache
+                    .direct(&file.blocks, &mut fd)
+                    .await
+                    .with_context(|| format!("failed to create download file '{:?}'", rooted))?;
+            }
+            _ => {}
+        };
+
+        Ok(())
+        //unimplemented!();
+    }
+}
+
+pub async fn extract<P: AsRef<Path> + Send + Sync>(
+    meta: &Metadata,
+    cache: &mut Cache,
+    root: P,
+) -> Result<()> {
+    let mut visitor = CopyVisitor {
+        meta,
+        cache,
+        root: root.as_ref(),
+    };
+
+    meta.walk(&mut visitor).await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ impl<'a> meta::WalkVisitor for CopyVisitor<'a> {
             .map(|a| a.mode & 0o777)
             .unwrap_or(0o666);
 
-        println!("creating file: {:?} {:?}", path.as_ref(), rooted);
         match &entry.kind {
             EntryKind::Dir(_) => {
                 fs::create_dir_all(&rooted)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -78,11 +78,9 @@ fn test_fs_with_md5sum_check() {
     let mops = TestMount::new(FLISTURL, MOUNTPOINT).unwrap();
     mops.mount().output().unwrap();
 
-    let current_directory = format!("{}", MOUNTPOINT);
-
     Command::new("md5sum")
         .args(["-c", "checksum.md5"])
-        .current_dir(current_directory)
+        .current_dir(MOUNTPOINT)
         .assert()
         .success();
 }
@@ -212,7 +210,7 @@ async fn test_extract() {
         .await
         .unwrap();
 
-    let path = "/tmp/extracted";
+    let path = Path::new("/tmp/extracted");
     let _ = fs::remove_dir_all(path);
     rfs::extract(&meta, &mut cache, path).await.unwrap();
 
@@ -224,7 +222,7 @@ async fn test_extract() {
 
     Command::new("md5sum")
         .args(["-c", "checksum.md5"])
-        .current_dir(format!("{}/symbolic_links", path))
+        .current_dir(path.join("symbolic_links"))
         .assert()
         .success();
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -212,7 +212,19 @@ async fn test_extract() {
         .await
         .unwrap();
 
-    rfs::extract(&meta, &mut cache, "/tmp/extracted")
-        .await
-        .unwrap();
+    let path = "/tmp/extracted";
+    let _ = fs::remove_dir_all(path);
+    rfs::extract(&meta, &mut cache, path).await.unwrap();
+
+    Command::new("md5sum")
+        .args(["-c", "checksum.md5"])
+        .current_dir(path)
+        .assert()
+        .success();
+
+    Command::new("md5sum")
+        .args(["-c", "checksum.md5"])
+        .current_dir(format!("{}/symbolic_links", path))
+        .assert()
+        .success();
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,7 +10,6 @@ const TMP_PATH: &str = "/tmp";
 
 const MOUNTPOINT: &str = "/tmp/rmnt";
 
-// const FLISTURL: &str = "https://hub.grid.tf/yasen.3bot/integration_test_fs.flist";
 const FLISTURL: &str = "https://hub.grid.tf/azmy.3bot/perm.flist";
 
 const PERMMASK: u32 = 0x1FF;
@@ -21,6 +20,51 @@ const READONLY: u32 = 0o444;
 const READEXEC: u32 = 0o555;
 const READWRITE: u32 = 0o666;
 const READWRITEEXEC: u32 = 0o777;
+
+struct TestMount<'a>(PathBuf, &'a str);
+
+impl<'a> TestMount<'a> {
+    pub fn new(flist: &'a str, mountpoint: &'a str) -> Result<Self> {
+        fs::create_dir_all(mountpoint).context("failed to create test mountpoint")?;
+
+        let (_, name) = flist
+            .rsplit_once("/")
+            .ok_or(anyhow::anyhow!("invalid flist path"))?;
+        let path = Path::new(TMP_PATH).join(name);
+        if !path.exists() {
+            let client = reqwest::blocking::Client::new();
+            let mut response = client.get(flist).send().context("failed to get flist")?;
+            let mut fd = std::fs::File::create(&path).context("failed to create temp flist")?;
+            response
+                .copy_to(&mut fd)
+                .context("failed to download flist")?;
+        }
+
+        Ok(TestMount(path, mountpoint))
+    }
+
+    pub fn mount(&self) -> Command {
+        let mut cmd = Command::cargo_bin("rfs").unwrap();
+        cmd.arg("-d")
+            .arg("--log")
+            .arg("/tmp/test-rmb.log")
+            .arg("--meta")
+            .arg(&self.0)
+            .arg(self.1);
+
+        cmd
+    }
+
+    fn unmount(&self) {
+        let _ = Command::new("umount").arg(self.1).output();
+    }
+}
+
+impl<'a> Drop for TestMount<'a> {
+    fn drop(&mut self) {
+        self.unmount();
+    }
+}
 
 #[test]
 fn test_sucess_mount() {
@@ -117,47 +161,58 @@ fn test_fail_call_bin_without_meta_argument() {
     assert.failure();
 }
 
-struct TestMount<'a>(PathBuf, &'a str);
+#[tokio::test]
+async fn test_walk() {
+    let mops = TestMount::new(FLISTURL, MOUNTPOINT).unwrap();
+    use rfs::meta::{EntryKind, Metadata, WalkVisitor};
+    let meta = Metadata::open(&mops.0).await.unwrap();
 
-impl<'a> TestMount<'a> {
-    pub fn new(flist: &'a str, mountpoint: &'a str) -> Result<Self> {
-        fs::create_dir_all(mountpoint).context("failed to create test mountpoint")?;
+    //let mut paths = vec![];
 
-        let (_, name) = flist
-            .rsplit_once("/")
-            .ok_or(anyhow::anyhow!("invalid flist path"))?;
-        let path = Path::new(TMP_PATH).join(name);
-        if !path.exists() {
-            let client = reqwest::blocking::Client::new();
-            let mut response = client.get(flist).send().context("failed to get flist")?;
-            let mut fd = std::fs::File::create(&path).context("failed to create temp flist")?;
-            response
-                .copy_to(&mut fd)
-                .context("failed to download flist")?;
+    struct TestVisitor {
+        paths: Vec<PathBuf>,
+    }
+    #[async_trait::async_trait]
+    impl WalkVisitor for TestVisitor {
+        async fn visit<P: AsRef<Path> + Send + Sync>(
+            &mut self,
+            path: P,
+            entry: &rfs::meta::Entry,
+        ) -> Result<()> {
+            self.paths.push(path.as_ref().to_owned());
+
+            if path.as_ref() == Path::new("/file_5M.random") {
+                assert!(matches!(entry.kind, EntryKind::File(_)));
+            } else if path.as_ref() == Path::new("/file_permissions") {
+                assert!(matches!(entry.kind, EntryKind::Dir(_)));
+            } else if path.as_ref() == Path::new("/symbolic_links/file_5M.random") {
+                assert!(matches!(entry.kind, EntryKind::Link(_)));
+            }
+
+            Ok(())
         }
-
-        Ok(TestMount(path, mountpoint))
     }
 
-    pub fn mount(&self) -> Command {
-        let mut cmd = Command::cargo_bin("rfs").unwrap();
-        cmd.arg("-d")
-            .arg("--log")
-            .arg("/tmp/test-rmb.log")
-            .arg("--meta")
-            .arg(&self.0)
-            .arg(self.1);
+    let mut visitor = TestVisitor { paths: vec![] };
+    //let inner = Arc::clone(&paths);
+    meta.walk(&mut visitor).await.unwrap();
 
-        cmd
-    }
-
-    fn unmount(&self) {
-        let _ = Command::new("umount").arg(self.1).output();
-    }
+    assert_eq!(24, visitor.paths.len());
 }
 
-impl<'a> Drop for TestMount<'a> {
-    fn drop(&mut self) {
-        self.unmount();
-    }
+#[tokio::test]
+async fn test_extract() {
+    let mops = TestMount::new(FLISTURL, MOUNTPOINT).unwrap();
+    use rfs::cache::Cache;
+    use rfs::meta::Metadata;
+
+    let meta = Metadata::open(&mops.0).await.unwrap();
+
+    let mut cache = Cache::new("redis://hub.grid.tf:9900", "/tmp/ex-cache")
+        .await
+        .unwrap();
+
+    rfs::extract(&meta, &mut cache, "/tmp/extracted")
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
Create an rfs crate that can be used to directly work with flists. 

- Currently the tool provide only an `extract` function given the metadata and the cache and the extractor library.
- The user can still use the cache to implement any kind of visitor to walk the file tree.

